### PR TITLE
Fix debug integration.

### DIFF
--- a/debug-trace.js
+++ b/debug-trace.js
@@ -45,8 +45,8 @@ module.exports = function (options) {
       var stack = callsite();
       var trace = stack[1];
       var file = trace.getFileName() || '';
-      if(stack.length > 2 && ~file.indexOf('debug.js')){
-        trace = stack[2];
+      if(stack.length > 2 && ~file.indexOf('debug/node.js')){
+        trace = stack[3];
         trace.debug = true;
       }
       trace.debug = trace.debug || false;


### PR DESCRIPTION
`debug` integration broke a few versions of `debug` ago when the project was restructured.

This is a pretty brittle solution but it works. 
