### PR TITLE
Handle unknown file without crash.

### DIFF
--- a/debug-trace.js
+++ b/debug-trace.js
@@ -64,7 +64,8 @@ module.exports = function debugTrace(options) {
 
 console.traceFormat = function (call, method) {
   var options = {};
-  call.filename = call.getFileName().replace(console.traceOptions.cwd, '');
+  var fileName = call.getFileName();
+  call.filename = (fileName || '<unknown file>').replace(console.traceOptions.cwd, '');
   call.method = method;
   call.functionName = call.getFunctionName() || 'anonymous'
   call.getDate = function getDate() {


### PR DESCRIPTION
I've seen this happen in an internal app on Node 8 (but not on Node 6) - simple fix.